### PR TITLE
Proper bip32 account shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ val wallet = Wallet.fromSeed(hrp, seed)
 // Convert a mnemonic into a wallet.
 val wallet = Wallet.fromMnemonic(hrp, wordlist)
 
-// Convert a base58-encoded bip32 key into a wallet.
-val wallet = Wallet.fromBip32(hrp, base58EncodedBip32Key)
+// Convert a base58-encoded bip32 key into an account.
+val account = Account.fromBip32(hrp, base58EncodedBip32Key)
 
 // Derive a child key from the root wallet.
 val testnetPath = "m/44'/1'/0'/0/0"

--- a/bip32/src/main/kotlin/io/provenance/hdwallet/bip32/MasterKey.kt
+++ b/bip32/src/main/kotlin/io/provenance/hdwallet/bip32/MasterKey.kt
@@ -96,6 +96,10 @@ data class ExtKey(
         path.parseBIP44Path().fold(this) { acc, i -> acc.childKey(i.number, i.hardened) }
 
     fun childKey(index: Int, hardened: Boolean = true): ExtKey {
+        if (depth == AccountType.ADDRESS) {
+            throw KeyException("cannot create key beyond current scope $depth")
+        }
+
         if (hardened && keyPair.privateKey.key == BigInteger.ZERO) {
             throw KeyException("private key required for hardened child keys")
         }

--- a/hdwallet/src/main/kotlin/io/provenance/hdwallet/hrp/Hrp.kt
+++ b/hdwallet/src/main/kotlin/io/provenance/hdwallet/hrp/Hrp.kt
@@ -1,0 +1,8 @@
+package io.provenance.hdwallet.hrp
+
+enum class Hrp(val mainnet: String, val testnet: String) {
+    CosmosHub("cosmos", "cosmos"),
+    CryptoOrg("cro", "tcro"),
+    ProvenanceBlockchain("pb", "tp"),
+    ;
+}

--- a/hdwallet/src/main/kotlin/io/provenance/hdwallet/wallet/Wallet.kt
+++ b/hdwallet/src/main/kotlin/io/provenance/hdwallet/wallet/Wallet.kt
@@ -15,16 +15,6 @@ interface Wallet {
     operator fun get(path: String): Account = get(PathElements.from(path))
 
     companion object {
-        fun fromBip32(hrp: String, bip32: String): Wallet {
-            val data = try {
-                bip32.base58DecodeChecked()
-            } catch (e: Throwable) {
-                // Eat the exception so no sensitive info gets logged.
-                throw KeyException()
-            }
-            return DefaultWallet(hrp, ExtKey.deserialize(data))
-        }
-
         fun fromSeed(hrp: String, seed: DeterministicSeed): Wallet =
             DefaultWallet(hrp, seed.toRootKey())
 
@@ -38,6 +28,18 @@ interface Account {
     val keyPair: ECKeyPair
     fun sign(payload: ByteArray): ByteArray
     operator fun get(index: Int, hardened: Boolean = true): Account
+
+    companion object {
+        fun fromBip32(hrp: String, bip32: String): Account {
+            val data = try {
+                bip32.base58DecodeChecked()
+            } catch (e: Throwable) {
+                // Eat the exception so no sensitive info gets logged.
+                throw KeyException()
+            }
+            return DefaultAccount(hrp, ExtKey.deserialize(data))
+        }
+    }
 }
 
 interface Discoverer {

--- a/hdwallet/src/test/kotlin/io/provenance/hdwallet/wallet/TestWallet.kt
+++ b/hdwallet/src/test/kotlin/io/provenance/hdwallet/wallet/TestWallet.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
 import java.util.stream.Collectors
-import kotlin.streams.toList
 
 class TestWallet {
     private data class WalletData(val path: String, val address: String, val publicKey: String, val privateKey: String, val signature: String)
@@ -27,11 +26,8 @@ class TestWallet {
     }
 
     private fun runBip32Test(seed: DeterministicSeed, walletData: WalletData) {
-        val encodedKey = seed.toRootKey().serialize().base58EncodeChecked()
-        val wallet: Wallet = Wallet.fromBip32("cosmos", encodedKey)
-
-        val childKey = wallet[walletData.path]
-
+        val encodedKey = seed.toRootKey().childKey(walletData.path).serialize().base58EncodeChecked()
+        val childKey: Account = Account.fromBip32("cosmos", encodedKey)
         val sig = childKey.sign( "test".toByteArray().sha256())
         Assert.assertEquals(childKey.address, walletData.address)
     }


### PR DESCRIPTION
`Wallet.fromBip32` was a misnomer. Updated to `Account.fromBip32` because it makes more sense from end user perspective.