### PR TITLE
Wallet - new create methods and arguments

### DIFF
--- a/hdwallet/src/main/kotlin/io/provenance/hdwallet/wallet/Wallet.kt
+++ b/hdwallet/src/main/kotlin/io/provenance/hdwallet/wallet/Wallet.kt
@@ -15,11 +15,85 @@ interface Wallet {
     operator fun get(path: String): Account = get(PathElements.from(path))
 
     companion object {
-        fun fromSeed(hrp: String, seed: DeterministicSeed): Wallet =
-            DefaultWallet(hrp, seed.toRootKey())
+        /**
+         * Create a new wallet from a root key.
+         *
+         * @param hrp The human-readable prefix to use when generating bech32 addresses from this wallet.
+         * @param rootKey The root key to use when generating this wallet.
+         * @return [Wallet]
+         */
+        fun fromRootKey(hrp: String, rootKey: ExtKey): Wallet = DefaultWallet(hrp, rootKey)
 
-        fun fromMnemonic(hrp: String, passphrase: CharArray, mnemonicWords: MnemonicWords): Wallet =
-            fromSeed(hrp, mnemonicWords.toSeed(passphrase))
+        /**
+         * Create a new wallet from a deterministic seed value.
+         *
+         * @param hrp The human-readable prefix to use when generating bech32 addresses from this wallet.
+         * @param seed The deterministic seed used to generate this wallet.
+         * @param testnet A flag that specifies if this wallet corresponds to a test net. If omitted, the default
+         * `false` will be used.
+         * @return [Wallet]
+         */
+        fun fromSeed(hrp: String, seed: DeterministicSeed, testnet: Boolean = false): Wallet =
+            DefaultWallet(hrp, seed.toRootKey(testnet = testnet))
+
+        /**
+         * Create a new wallet from a BIP32 mnemonic phrase.
+         *
+         * Example:
+         *
+         * ```kotlin
+         * val wallet: Wallet = Wallet.fromMnemonic(
+         *   hrp = "tp",
+         *   passphrase = "".toCharArray(),
+         *   mnemonicWords = MnemonicWords.of("home used crowd sphere kick taxi strategy just punch admit speak enable"),
+         * )
+         * ```
+         *
+         * @param hrp The human-readable prefix to use when generating bech32 addresses from this wallet.
+         * @param passphrase The passphrase to use when generating the seed that will be used to create this wallet.
+         * @param mnemonicWords The BIP39 mnemonic phrase to use to generate the seed for this wallet.
+         * @param testnet A flag that specifies if this wallet corresponds to a test net. If omitted, the default
+         * `false` will be used.
+         * @return [Wallet]
+         */
+        fun fromMnemonic(
+            hrp: String,
+            passphrase: CharArray,
+            mnemonicWords: MnemonicWords,
+            testnet: Boolean = false
+        ): Wallet = fromSeed(hrp = hrp, seed = mnemonicWords.toSeed(passphrase), testnet = testnet)
+
+        /**
+         * Create a new wallet from a BIP32 mnemonic phrase.
+         *
+         * Example:
+         *
+         * ```kotlin
+         * val wallet: Wallet = Wallet.fromMnemonic(
+         *   hrp = "tp",
+         *   passphrase = "",
+         *   mnemonicWords = MnemonicWords.of("home used crowd sphere kick taxi strategy just punch admit speak enable"),
+         * )
+         * ```
+         *
+         * @param hrp The human-readable prefix to use when generating bech32 addresses from this wallet.
+         * @param passphrase The passphrase to use when generating the seed that will be used to create this wallet.
+         * @param mnemonicWords The BIP39 mnemonic phrase to use to generate the seed for this wallet.
+         * @param testnet A flag that specifies if this wallet corresponds to a test net. If omitted, the default
+         * `false` will be used.
+         * @return [Wallet]
+         */
+        fun fromMnemonic(
+            hrp: String,
+            passphrase: String,
+            mnemonicWords: MnemonicWords,
+            testnet: Boolean = false
+        ): Wallet = fromMnemonic(
+            hrp = hrp,
+            passphrase = passphrase.toCharArray(),
+            mnemonicWords = mnemonicWords,
+            testnet = testnet
+        )
     }
 }
 


### PR DESCRIPTION
- Add new `Wallet.fromRootKey()` creational method
- Expose `testNet` parameter in `Wallet.fromSeed` and `Wallet.fromMnemonic`