### PR TITLE
Small patch PR (12/30/2021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Current published version:
 
 ## Gradle
 
-```
+```kotlin
 implementation("io.provenance.hdwallet", "hdwallet", "$version")
 ```
 
@@ -31,40 +31,40 @@ implementation("io.provenance.hdwallet", "hdwallet", "$version")
 ### Shortcut versions
 
 ```kotlin
-// Convert a seed into a wallet.
+// Convert a seed into a wallet:
 val wallet = Wallet.fromSeed(hrp, seed)
 
-// Convert a mnemonic into a wallet.
-val wallet = Wallet.fromMnemonic(hrp, wordlist)
+// Convert a mnemonic into a wallet:
+val wallet = Wallet.fromMnemonic(hrp, "passphrase".toCharArray(), wordlist)
 
-// Convert a base58-encoded bip32 key into an account.
+// Convert a base58-encoded bip32 key into an account:
 val account = Account.fromBip32(hrp, base58EncodedBip32Key)
 
-// Derive a child key from the root wallet.
+// Derive a child key from the root wallet:
 val testnetPath = "m/44'/1'/0'/0/0"
 val childKey = wallet[testnetPath]
 
-// Sign a payload
-val signature = BCECSigner().sign(childKey.keyPair.privateKey, "test".toByteArray().sha256())
+// Sign a payload:
+val signature = BCECSigner().sign(childKey.keyPair.privateKey, "test-payload".toByteArray().sha256())
 ```
 
 ### Full key derivation (the shortcuts outlined above perform the following for you).
 
 ```kotlin
-// Generate the seed from the mnemonic + passphrase.
+// Generate the seed from the mnemonic + passphrase:
 val seed = MnemonicWords.of("hip valley wave rider ... ...").toSeed("trezor".toCharArray())
 
-// Derive the root extkey.
+// Derive the root extended key:
 val rootKey = seed.toRootKey(/* curve = secp256k1 */) // optional curve parameter, default: secp256k1
 
-// Derive the child key based on path.
+// Derive the child key based on path:
 val testnetPath = "m/44'/1'/0'/0/0"
 val childKey = rootKey.childKey(testnetPath)
 
-// Create a new BouncyCastle signer
+// Create a new BouncyCastle signer:
 val signer = BCECSigner()
 
-// Generate an ecdsa signature.
+// Generate an ECDSA signature:
 val payloadHash = "test".toByteArray().sha256()
 val sig = signer.sign(childKey.keyPair.privateKey, payloadHash)
 ```

--- a/ec/src/main/kotlin/io/provenance/hdwallet/ec/JavaKeys.kt
+++ b/ec/src/main/kotlin/io/provenance/hdwallet/ec/JavaKeys.kt
@@ -3,26 +3,52 @@ package io.provenance.hdwallet.ec
 import io.provenance.hdwallet.ec.bc.toCurvePoint
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey
-import org.bouncycastle.jce.ECNamedCurveTable
 import org.bouncycastle.jce.spec.ECParameterSpec
 import org.bouncycastle.jce.spec.ECPrivateKeySpec
 import java.security.KeyFactory
+import java.security.spec.ECPublicKeySpec
 import java.security.PrivateKey as JavaPrivateKey
 import java.security.PublicKey as JavaPublicKey
 
 private fun ECParameterSpec.toCurve() = Curve(n, g.toCurvePoint(), curve)
 
+/**
+ * Convert a Java cryptographic [JavaPublicKey] to a hdwallet library [PublicKey].
+ *
+ * @return The converted public key, [PublicKey].
+ */
 fun JavaPublicKey.toECPublicKey(): PublicKey {
     val bcec = requireNotNull(this as? BCECPublicKey) { "key type invalid" }
     return PublicKey(bcec.q.getEncoded(true).toBigInteger(), bcec.parameters.toCurve())
 }
 
+/**
+ * Convert a Java cryptographic [JavaPrivateKey] to a hdwallet library [PrivateKey].
+ *
+ * @return The converted private key, [PrivateKey].
+ */
 fun JavaPrivateKey.toECPrivateKey(): PrivateKey {
     val bcec = requireNotNull(this as? BCECPrivateKey) { "key type invalid" }
     return PrivateKey(bcec.d, bcec.parameters.toCurve())
 }
 
-fun PrivateKey.toJavaPrivateKey(): JavaPrivateKey {
-    val keySpec = ECPrivateKeySpec(key, this.curve.bcecParameterSpec)
-    return KeyFactory.getInstance("EC").generatePrivate(keySpec)
-}
+/**
+ * Convert an instance of a hdwallet library [PublicKey] to a Java cryptographic [PublicKey].
+ *
+ * @return The converted Java public key, [JavaPublicKey].
+ */
+fun PublicKey.toJavaECPublicKey(): JavaPublicKey =
+    KeyFactory
+        .getInstance("EC")
+        .generatePublic(ECPublicKeySpec(point().toJavaECPoint(), curve.ecParameterSpec))
+
+/**
+ * Convert an instance of a hdwallet library [PrivateKey] to a Java cryptographic [JavaPrivateKey].
+ *
+ * @return The converted Java private key, [JavaPrivateKey].
+ */
+fun PrivateKey.toJavaPrivateKey(): JavaPrivateKey =
+    KeyFactory
+        .getInstance("EC")
+        .generatePrivate(ECPrivateKeySpec(key, curve.bcecParameterSpec))
+

--- a/hdwallet/src/main/kotlin/io/provenance/hdwallet/wallet/DefaultWallet.kt
+++ b/hdwallet/src/main/kotlin/io/provenance/hdwallet/wallet/DefaultWallet.kt
@@ -24,10 +24,12 @@ class DefaultAccount(hrp: String, key: ExtKey) : Account {
         key.keyPair.publicKey.compressed().sha256hash160().toBech32(hrp).address
 
     override val keyPair: ECKeyPair = key.keyPair
-    
+
     private val keyMaker = hrp to { index: Int, hard: Boolean -> key.childKey(index, hard) }
-    private val signateur = BCECSigner()
-    private val signer = { bytes: ByteArray -> signateur.sign(key.keyPair.privateKey, bytes.sha256()) }
+
+    private val signature = BCECSigner()
+
+    private val signer = { bytes: ByteArray -> signature.sign(key.keyPair.privateKey, bytes.sha256()) }
 
     override fun sign(payload: ByteArray): ByteArray =
         signer.invoke(payload).encodeAsBTC()


### PR DESCRIPTION
- Update docuemntation to reflect that Wallt.fromMnemonic() requires a
  passphrase

- Add missing PublicKey.toJavaECPublicKey() extension method.