### PR TITLE
Patch 2022-01-19

### DIFF
--- a/base58/src/main/kotlin/io/provenance/hdwallet/encoding/base58/Base58.kt
+++ b/base58/src/main/kotlin/io/provenance/hdwallet/encoding/base58/Base58.kt
@@ -2,7 +2,10 @@ package io.provenance.hdwallet.encoding.base58
 
 import io.provenance.hdwallet.encoding.shadow.org.bitcoinj.core.Base58
 
-fun ByteArray.base58Encode() = Base58.encode(this)
-fun String.base58Decode() = Base58.decode(this)
-fun ByteArray.base58EncodeChecked() = Base58.encodeChecked(this)
-fun String.base58DecodeChecked() = Base58.decodeChecked(this)
+fun ByteArray.base58Encode(): String = Base58.encode(this)
+
+fun String.base58Decode(): ByteArray = Base58.decode(this)
+
+fun ByteArray.base58EncodeChecked(): String = Base58.encodeChecked(this)
+
+fun String.base58DecodeChecked(): ByteArray = Base58.decodeChecked(this)

--- a/bip32/src/main/kotlin/io/provenance/hdwallet/bip32/MasterKey.kt
+++ b/bip32/src/main/kotlin/io/provenance/hdwallet/bip32/MasterKey.kt
@@ -63,7 +63,7 @@ data class ExtKey(
     val chainCode: ExtKeyChainCode,
     val keyPair: ECKeyPair
 ) {
-    private val curve = keyPair.privateKey.curve
+    private val curve: Curve = keyPair.privateKey.curve
 
     fun serialize(publicKeyOnly: Boolean = false): ByteArray {
         if (!publicKeyOnly && !(versionBytes.bytes.contentEquals(xprv)) && !(versionBytes.bytes contentEquals tprv))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ subprojects {
 
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         kotlinOptions {
-            jvmTarget = "1.8"
+            jvmTarget = "11"
         }
     }
 
@@ -68,8 +68,8 @@ subprojects {
     }
 
     configure<JavaPluginConvention> {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     repositories {

--- a/ec/src/main/kotlin/io/provenance/hdwallet/ec/Keys.kt
+++ b/ec/src/main/kotlin/io/provenance/hdwallet/ec/Keys.kt
@@ -58,4 +58,6 @@ class PublicKey(val key: BigInteger, val curve: Curve) {
  * @property privateKey The private key.
  * @property publicKey The public key.
  */
-data class ECKeyPair(val privateKey: PrivateKey, val publicKey: PublicKey)
+data class ECKeyPair(val privateKey: PrivateKey, val publicKey: PublicKey) {
+    fun toPair(): Pair<PrivateKey, PublicKey> = Pair(privateKey, publicKey)
+}

--- a/ec/src/main/kotlin/io/provenance/hdwallet/ec/extensions/BC.kt
+++ b/ec/src/main/kotlin/io/provenance/hdwallet/ec/extensions/BC.kt
@@ -4,7 +4,6 @@ import io.provenance.hdwallet.ec.Curve
 import io.provenance.hdwallet.ec.CurvePoint
 import java.math.BigInteger
 import java.security.KeyFactory
-import java.security.interfaces.ECPublicKey
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.X509EncodedKeySpec
 import org.bouncycastle.asn1.x9.X9ECParameters
@@ -15,6 +14,7 @@ import org.bouncycastle.jce.spec.ECParameterSpec
 import org.bouncycastle.math.ec.ECPoint
 import java.security.PrivateKey as JavaPrivateKey
 import java.security.PublicKey as JavaPublicKey
+import java.security.interfaces.ECPublicKey as JavaECPublicKey
 
 fun X9ECParameters.toCurve(): Curve = Curve(n, g.toCurvePoint(), curve)
 

--- a/ec/src/main/kotlin/io/provenance/hdwallet/ec/extensions/JavaKeys.kt
+++ b/ec/src/main/kotlin/io/provenance/hdwallet/ec/extensions/JavaKeys.kt
@@ -1,5 +1,6 @@
 package io.provenance.hdwallet.ec.extensions
 
+import io.provenance.hdwallet.ec.ECKeyPair
 import io.provenance.hdwallet.ec.PrivateKey
 import io.provenance.hdwallet.ec.PublicKey
 import io.provenance.hdwallet.ec.bcecParameterSpec
@@ -11,6 +12,7 @@ import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.jce.spec.ECPrivateKeySpec
 import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider
+import java.security.KeyPair as JavaKeyPair
 import java.security.PrivateKey as JavaPrivateKey
 import java.security.PublicKey as JavaPublicKey
 import java.security.interfaces.ECPrivateKey as JavaECPrivateKey
@@ -26,7 +28,7 @@ fun JavaECPublicKey.toBCECPublicKey(): BCECPublicKey = BCECPublicKey(this, Bounc
 /**
  * Convert a Sun Security Provider [JavaPublicKey] to a Bouncy Castle elliptic curve (EC) public key, [BCECPublicKey].
  *
- * @return [BCECPublicKey] if the underlying key is a subclass of [ECPublicKey], or null if otherwise.
+ * @return [BCECPublicKey] if the underlying key is a subclass of [BCECPublicKey], or null if otherwise.
  */
 fun JavaPublicKey.toBCECPublicKey(): BCECPublicKey? =
     when (this) {
@@ -93,3 +95,31 @@ fun JavaPrivateKey.toECPrivateKey(): PrivateKey {
     val bcec = requireNotNull(toBCECPrivateKey()) { "key type invalid: not EC" }
     return PrivateKey(bcec.d, bcec.parameters.toCurve())
 }
+
+/**
+ * Convert a hdwallet elliptic curve keypair into a [JavaKeyPair].
+ *
+ * @return The converted Java [JavaKeyPair].
+ */
+fun ECKeyPair.toJavaECKeyPair(): JavaKeyPair = JavaKeyPair(publicKey.toJavaECPublicKey(), privateKey.toJavaECPrivateKey())
+
+/**
+ * Convert a Java [JavaKeyPair] into an hdwallet [ECKeyPair].
+ *
+ * @return The converted hdwallet [ECKeyPair].
+ */
+fun JavaKeyPair.toECKeyPair(): ECKeyPair = ECKeyPair(private.toECPrivateKey(), public.toECPublicKey())
+
+/**
+ * Convert a [Pair<JavaPublicKey, JavaPrivateKey>] to a [JavaKeyPair].
+ *
+ * @return [JavaKeyPair]
+ */
+fun Pair<JavaPublicKey, JavaPrivateKey>.toKeyPair(): JavaKeyPair = JavaKeyPair(first, second)
+
+/**
+ * Convert a [JavaKeyPair] to a [Pair] of <[JavaPublicKey], [JavaPrivateKey]>.
+ *
+ * @return A [Pair] of public, private keys.
+ */
+fun JavaKeyPair.toPair(): Pair<JavaPublicKey, JavaPrivateKey> = Pair(public, private)

--- a/signer/src/main/kotlin/io/provenance/hdwallet/signer/BCECSigner.kt
+++ b/signer/src/main/kotlin/io/provenance/hdwallet/signer/BCECSigner.kt
@@ -2,6 +2,7 @@ package io.provenance.hdwallet.signer
 
 import io.provenance.hdwallet.ec.PrivateKey
 import io.provenance.hdwallet.ec.PublicKey
+import java.math.BigInteger
 import org.bouncycastle.crypto.digests.SHA256Digest
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters
 import org.bouncycastle.crypto.params.ECPublicKeyParameters
@@ -19,7 +20,7 @@ open class BCECSigner : SignAndVerify {
 
     override fun sign(privateKey: PrivateKey, payload: ByteArray): ECDSASignature {
         val params = ECPrivateKeyParameters(privateKey.key, privateKey.curve.ecDomainParameters)
-        val (r, s) = signer {
+        val (r: BigInteger, s: BigInteger) = signer {
             init(true, params)
             generateSignature(payload)
         }

--- a/signer/src/test/kotlin/io/provenance/hdwallet/signer/TestECDSASignature.kt
+++ b/signer/src/test/kotlin/io/provenance/hdwallet/signer/TestECDSASignature.kt
@@ -3,14 +3,28 @@ package io.provenance.hdwallet.signer
 import io.provenance.hdwallet.bip32.ExtKey
 import io.provenance.hdwallet.bip32.toRootKey
 import io.provenance.hdwallet.bip39.MnemonicWords
+import io.provenance.hdwallet.common.bc.registerBouncyCastle
 import io.provenance.hdwallet.common.hashing.sha256
+import io.provenance.hdwallet.ec.extensions.toECPrivateKey
+import io.provenance.hdwallet.ec.extensions.toECPublicKey
 import io.provenance.hdwallet.ec.secp256k1Curve
 import io.provenance.hdwallet.ec.secp256r1Curve
 import io.provenance.hdwallet.encoding.base16.base16Decode
 import io.provenance.hdwallet.encoding.base16.base16Encode
 import java.math.BigInteger
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.SecureRandom
+import java.security.Signature
+import java.security.SignatureException
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 object paths {
     val testnet = "m/44'/1'/0'/0/0'"
@@ -25,7 +39,8 @@ val mnemonic = MnemonicWords.of(
     "defense legal stem absorb hurdle physical prosper review process primary exist camera"
 )
 val seed = mnemonic.toSeed("".toCharArray())
-val payloadHash = "test".toByteArray().sha256()
+val payload = "test".toByteArray()
+val payloadHash = payload.sha256()
 
 val expected = mapOf(
     secp256k1Curve to ExpectedSigs(
@@ -70,6 +85,21 @@ val expected = mapOf(
 )
 
 class TestItAll {
+    private val randomSeed: ByteArray = byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())
+    private val random = SecureRandom(randomSeed)
+
+    private fun createECKeyPair(keySize: Int = 256): Pair<PublicKey, PrivateKey> {
+        val keyGen = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME)
+        keyGen.initialize(keySize, random)
+        val pair: KeyPair = keyGen.generateKeyPair()
+        return Pair(pair.public, pair.private)
+    }
+
+    @BeforeEach
+    fun setup() {
+        registerBouncyCastle()
+    }
+
     @Test
     fun testRun() {
         data class Keys(val root: ExtKey) {
@@ -96,25 +126,102 @@ class TestItAll {
 
                 assertEquals(ekp.expectedRoot.r, rootSig.r, "${test.javaClass.simpleName} $name root r")
                 assertEquals(ekp.expectedRoot.s, rootSig.s, "${test.javaClass.simpleName} $name root s")
-                assertEquals(ekp.expectedRoot.btc.base16Encode(), rootSig.encodeAsBTC().base16Encode(), "${test.javaClass.simpleName} $name root btc")
-                assertEquals(true, signer.verify(keys.root.keyPair.publicKey, payloadHash, rootSig), "${test.javaClass.simpleName} $name root verify")
+                assertEquals(
+                    ekp.expectedRoot.btc.base16Encode(),
+                    rootSig.encodeAsBTC().base16Encode(),
+                    "${test.javaClass.simpleName} $name root btc"
+                )
+                assertEquals(
+                    true,
+                    signer.verify(keys.root.keyPair.publicKey, payloadHash, rootSig),
+                    "${test.javaClass.simpleName} $name root verify"
+                )
 
                 assertEquals(ekp.expectedTestnet.r, testnetSig.r, "${test.javaClass.simpleName} $name test r")
                 assertEquals(ekp.expectedTestnet.s, testnetSig.s, "${test.javaClass.simpleName} $name test s")
-                assertEquals(ekp.expectedTestnet.btc.base16Encode(), testnetSig.encodeAsBTC().base16Encode(), "${test.javaClass.simpleName} $name test btc")
-                assertEquals(true, signer.verify(keys.testnet.keyPair.publicKey, payloadHash, testnetSig), "${test.javaClass.simpleName} $name test verify")
+                assertEquals(
+                    ekp.expectedTestnet.btc.base16Encode(),
+                    testnetSig.encodeAsBTC().base16Encode(),
+                    "${test.javaClass.simpleName} $name test btc"
+                )
+                assertEquals(
+                    true,
+                    signer.verify(keys.testnet.keyPair.publicKey, payloadHash, testnetSig),
+                    "${test.javaClass.simpleName} $name test verify"
+                )
 
-                assertEquals(ekp.expectedMainnet.r, mainnetSig.r, "${test.javaClass.simpleName} $name main r",)
-                assertEquals(ekp.expectedMainnet.s, mainnetSig.s, "${test.javaClass.simpleName} $name main s",)
-                assertEquals(ekp.expectedMainnet.btc.base16Encode(), mainnetSig.encodeAsBTC().base16Encode(), "${test.javaClass.simpleName} $name main btc",)
-                assertEquals(true, signer.verify(keys.mainnet.keyPair.publicKey, payloadHash, mainnetSig), "${test.javaClass.simpleName} $name main verify")
+                assertEquals(ekp.expectedMainnet.r, mainnetSig.r, "${test.javaClass.simpleName} $name main r")
+                assertEquals(ekp.expectedMainnet.s, mainnetSig.s, "${test.javaClass.simpleName} $name main s")
+                assertEquals(
+                    ekp.expectedMainnet.btc.base16Encode(),
+                    mainnetSig.encodeAsBTC().base16Encode(),
+                    "${test.javaClass.simpleName} $name main btc",
+                )
+                assertEquals(
+                    true,
+                    signer.verify(keys.mainnet.keyPair.publicKey, payloadHash, mainnetSig),
+                    "${test.javaClass.simpleName} $name main verify"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testSignatureEncoding() {
+        val keyPair = createECKeyPair()
+        val publicKey = keyPair.first
+        val privateKey = keyPair.second
+
+        fun JCESignature(): Signature = Signature.getInstance("SHA256withECDSA")
+        fun BCSignature(): Signature = Signature.getInstance("SHA256withECDSA", BouncyCastleProvider.PROVIDER_NAME)
+
+        val signatureBytesGoodFormat: ByteArray = BCECSigner().run {
+            sign(privateKey.toECPrivateKey(), payloadHash).encodeAsASN1DER()
+        }
+
+        val signatureBytesBadFormat: ByteArray = BCECSigner().run {
+            sign(privateKey.toECPrivateKey(), payloadHash).encodeAsBTC()
+        }
+
+        // Providers should be different:
+        assert(JCESignature().provider.info != BCSignature().provider.info)
+
+        // BTC encoding should fail on both:
+        assertThrows<SignatureException> {
+            JCESignature().run {
+                initVerify(publicKey)
+                update(payload)
+                verify(signatureBytesBadFormat)
+            }
+        }
+        assertThrows<SignatureException> {
+            BCSignature().run {
+                initVerify(publicKey)
+                update(payload)
+                verify(signatureBytesBadFormat)
             }
         }
 
+        // DER encoding should succeed for both:
+        assert(JCESignature().run {
+            initVerify(publicKey)
+            update(payload)
+            verify(signatureBytesGoodFormat)
+        })
+        assert(BCSignature().run {
+            initVerify(publicKey)
+            update(payload)
+            verify(signatureBytesGoodFormat)
+        })
     }
 }
 
-data class ExpectedSigs(val expectedRoot: ExpectedSig, val expectedTestnet: ExpectedSig, val expectedMainnet: ExpectedSig)
+data class ExpectedSigs(
+    val expectedRoot: ExpectedSig,
+    val expectedTestnet: ExpectedSig,
+    val expectedMainnet: ExpectedSig
+)
+
 data class ExpectedSig(val r: BigInteger, val s: BigInteger, val btc: ByteArray)
 
 class TestBCECDSASignature : TestECDSASignature {


### PR DESCRIPTION
- Update readme with key conversion examples

- Update required Java compatibility from Java 1.8 to 11

- Add extension methods for convert `ECKeyPair` to `java.security.KeyPair`

- Add `ECDSASignature.encodeAsASN1DER()` method to produce a signature
  byte array that can be used with Java's
  `java.security.Signature.getInstance("SHA256withECDSA")` for
  verification

- Make types more explicit