### PR TITLE
Bug Fix: Fix conversion from BCECPublicKey to hdwallet PublicKey

### DIFF
--- a/ec/src/main/kotlin/io/provenance/hdwallet/ec/Compression.kt
+++ b/ec/src/main/kotlin/io/provenance/hdwallet/ec/Compression.kt
@@ -1,12 +1,33 @@
 package io.provenance.hdwallet.ec
 
+import io.provenance.hdwallet.ec.extensions.toBigInteger
 import java.math.BigInteger
+import java.nio.ByteBuffer
 
 internal const val PUBLIC_KEY_SIZE = 64
 
-fun decompressPublicKey(compressedBytes: ByteArray, curve: Curve): BigInteger {
+/**
+ * In Bitcoin, public keys are either compressed or uncompressed. Compressed public keys are 33 bytes,
+ * consisting of a prefix either 0x02 or 0x03, and a 256-bit integer called x.
+ * The older uncompressed keys are 65 bytes, consisting of constant prefix (0x04),
+ * followed by two 256-bit integers called x and y (2 * 32 bytes).
+ *
+ * @param compressedBytes The compressed public key bytes to decompress.
+ * @param curve The curve to use for decoding the public key point.
+ * @return If [encode] is true, The public key will be a packed [BigInteger] 65 bytes long, where the first byte is
+ * 0x04, followed by a 32-byte x point coordinate, and a 32-byte y point coordinate. If [encode] is false, the
+ * returned [BigInteger] will be 64 bytes, consisting of a 32-byte x point coordinate, followed by a 32-byte y point
+ * coordinate.
+ */
+fun decompressPublicKey(compressedBytes: ByteArray, curve: Curve, encode: Boolean = false): BigInteger {
     val point = curve.decodePoint(compressedBytes)
-    val encoded = point.encoded(true)
-    return BigInteger(encoded.copyOfRange(1, encoded.size))
+    val x = point.ecPoint.xCoord.encoded
+    val y = point.ecPoint.yCoord.encoded
+    val bb = ByteBuffer.allocate(PUBLIC_KEY_SIZE + if (encode) 1 else 0)
+    if (encode) {
+        bb.put(0x04)
+    }
+    bb.put(x)
+    bb.put(y)
+    return bb.array().toBigInteger()
 }
-

--- a/ec/src/test/kotlin/io/provenance/hdwallet/ec/util/Keys.kt
+++ b/ec/src/test/kotlin/io/provenance/hdwallet/ec/util/Keys.kt
@@ -1,0 +1,19 @@
+package io.provenance.hdwallet.ec.util
+
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.SecureRandom
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+
+private val seed: ByteArray = byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())
+
+private val seededRandom = SecureRandom(seed)
+
+fun createECKeyPair(keySize: Int = 256, random: SecureRandom = seededRandom): Pair<PublicKey, PrivateKey> {
+    val keyGen = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME)
+    keyGen.initialize(keySize, random)
+    val pair: KeyPair = keyGen.generateKeyPair()
+    return Pair(pair.public, pair.private)
+}


### PR DESCRIPTION
- Fixes a bug I introduced in `fun JavaPublicKey.toECPublicKey()`, where the encoded `q` value was being used directly as the publikc key `BigInteger`. Now, the first byte is being lopped off, leaving a 64 byte array(), which encodes x & y coordinate components (32 bytes each) concatenated together.

- Fixes a bug in `decompressPublicKey`, so that the output is either 64 or 65 bytes and the following holds:
  * create an hdwallet `PublicKey` 
  * compress it to get a `ByteArray` 33 bytes long
  * pass the compressed bytes array to `decompressPublicKey()` and pack the contents into a `BigInteger`
  * use the big int to create a new `PublicKey`
  * check that the original public key and the reconstructed key have the same big int value.

